### PR TITLE
Combine multiple UI components into Feature component

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -29,6 +29,7 @@ import { PerspectiveComponent } from './ventures/ui/perspective/perspective.comp
 import { InnovativeComponent } from './ventures/ui/innovative/innovative.component';
 import { CircularComponent } from './ventures/ui/circular/circular.component';
 import { RtToHtmlPipe } from './pipes/rt-to-html.pipe';
+import { FeatureItemComponent } from './ventures/ui/feature-item/feature-item.component';
 
 @NgModule({
   declarations: [
@@ -57,7 +58,8 @@ import { RtToHtmlPipe } from './pipes/rt-to-html.pipe';
     PerspectiveComponent,
     InnovativeComponent,
     CircularComponent,
-    RtToHtmlPipe
+    RtToHtmlPipe,
+    FeatureItemComponent
   ],
   imports: [
     BrowserModule,

--- a/src/app/ventures/investing/investing.component.html
+++ b/src/app/ventures/investing/investing.component.html
@@ -13,8 +13,10 @@
     <app-hero [entry]="page.fields.component[0]"></app-hero>
     <app-feature [entry]="page.fields.component[1]"></app-feature>
     <app-feature [entry]="page.fields.component[2]"></app-feature>
-    <app-innovative [entry]="page.fields.component[3]"></app-innovative>
-    <app-perspective [entry]="page.fields.component[4]"></app-perspective>
+    <app-feature [entry]="page.fields.component[3]"></app-feature>
+    <app-feature [entry]="page.fields.component[4]"></app-feature>
+    <app-perspective [entry]="page.fields.component[5]"></app-perspective>
+    <app-feature [entry]="page.fields.component[6]"></app-feature>
 
   </div>
 </div>

--- a/src/app/ventures/investing/investing.component.html
+++ b/src/app/ventures/investing/investing.component.html
@@ -15,8 +15,7 @@
     <app-feature [entry]="page.fields.component[2]"></app-feature>
     <app-feature [entry]="page.fields.component[3]"></app-feature>
     <app-feature [entry]="page.fields.component[4]"></app-feature>
-    <app-perspective [entry]="page.fields.component[5]"></app-perspective>
-    <app-feature [entry]="page.fields.component[6]"></app-feature>
+    <app-feature [entry]="page.fields.component[5]"></app-feature>
 
   </div>
 </div>

--- a/src/app/ventures/investing/investing.component.ts
+++ b/src/app/ventures/investing/investing.component.ts
@@ -16,7 +16,7 @@ export class InvestingComponent implements OnInit {
     this.contentfulService.cdaClient.getEntries({
       content_type: 'page',
       'sys.id': '7tSaoV4RtIUJuLRhqrVzrm',
-      include: 3
+      include: 4
     }).then(page => {
       this.page = page.items[0];
       console.log(this.page);

--- a/src/app/ventures/ui/feature-item/feature-item.component.html
+++ b/src/app/ventures/ui/feature-item/feature-item.component.html
@@ -1,8 +1,15 @@
 <div class="row adjusted-3-col ventures-row" *ngFor="let row of entry.rowData">
   <div *ngIf="row.fields.columnType == 'Fixed'">
     <div class="col-xs-12 col-sm-3 spacing" *ngFor="let item of row.fields.itemData">
-      <h4>{{item.fields.header}}</h4>
-      <div [innerHTML]="item.fields.description | rtToHtml"></div>
+      <div *ngIf="item.sys.contentType.sys.id === 'featureItem'">
+        <h4>{{item.fields.header}}</h4>
+        <div [innerHTML]="item.fields.description | rtToHtml"></div>
+      </div>
+      <div *ngIf="item.sys.contentType.sys.id === 'innovative'">
+          <h3>{{ item.fields.name }}</h3>
+          <!--insert SINGLE innovative component here-->
+      </div>
+      <!-- continue to insert alternative components to be included within a feature-->
     </div>
   </div>
   <div *ngIf="row.fields.columnType == 'Flex'">

--- a/src/app/ventures/ui/feature-item/feature-item.component.html
+++ b/src/app/ventures/ui/feature-item/feature-item.component.html
@@ -1,0 +1,18 @@
+<div class="row adjusted-3-col ventures-row" *ngFor="let row of entry">
+  <div *ngIf="row.fields.columnType == 'Fixed'">
+    <div class="col-xs-12 col-sm-3 spacing" *ngFor="let item of row.fields.itemData">
+      <h4>{{item.fields.header}}</h4>
+      <div [innerHTML]="item.fields.description | rtToHtml"></div>
+    </div>
+  </div>
+  <div *ngIf="row.fields.columnType == 'Flex'">
+    <div [class.col-md-5]="row.fields.itemData.length == 2" [class.col-sm-5]="row.fields.itemData.length == 2"
+      [class.col-sm-3]="row.fields.itemData.length == 3" class="col-xs-12 col-sm-10 spacing"
+      *ngFor="let item of row.fields.itemData">
+      <h4>{{item.fields.header}}</h4>
+      <div [innerHTML]="item.fields.description | rtToHtml"></div>
+      <p *ngIf="item.fields.linkUrl"><a href="{{item.fields.linkUrl}}" class="cta chevron noGrow dark lm"
+          target="_blank">{{item.fields.linkText}}</a></p>
+    </div>
+  </div>
+</div>

--- a/src/app/ventures/ui/feature-item/feature-item.component.html
+++ b/src/app/ventures/ui/feature-item/feature-item.component.html
@@ -1,4 +1,4 @@
-<div class="row adjusted-3-col ventures-row" *ngFor="let row of entry">
+<div class="row adjusted-3-col ventures-row" *ngFor="let row of entry.rowData">
   <div *ngIf="row.fields.columnType == 'Fixed'">
     <div class="col-xs-12 col-sm-3 spacing" *ngFor="let item of row.fields.itemData">
       <h4>{{item.fields.header}}</h4>

--- a/src/app/ventures/ui/feature-item/feature-item.component.html
+++ b/src/app/ventures/ui/feature-item/feature-item.component.html
@@ -1,15 +1,8 @@
 <div class="row adjusted-3-col ventures-row" *ngFor="let row of entry.rowData">
   <div *ngIf="row.fields.columnType == 'Fixed'">
     <div class="col-xs-12 col-sm-3 spacing" *ngFor="let item of row.fields.itemData">
-      <div *ngIf="item.sys.contentType.sys.id === 'featureItem'">
-        <h4>{{item.fields.header}}</h4>
-        <div [innerHTML]="item.fields.description | rtToHtml"></div>
-      </div>
-      <div *ngIf="item.sys.contentType.sys.id === 'innovative'">
-          <h3>{{ item.fields.name }}</h3>
-          <!--insert SINGLE innovative component here-->
-      </div>
-      <!-- continue to insert alternative components to be included within a feature-->
+      <h4>{{item.fields.header}}</h4>
+      <div [innerHTML]="item.fields.description | rtToHtml"></div>
     </div>
   </div>
   <div *ngIf="row.fields.columnType == 'Flex'">

--- a/src/app/ventures/ui/feature-item/feature-item.component.scss
+++ b/src/app/ventures/ui/feature-item/feature-item.component.scss
@@ -1,0 +1,48 @@
+@media (min-width: 768px) {
+    .adjusted-3-col .col-sm-3 {
+      width: 25%;
+    }
+    .ventures-row > div > div:first-of-type {
+      margin-left: 8.33333333%;
+    }
+  }
+  
+  .ventures-feature a {
+    color: #0076D1;
+    background: url(/assets/images/arrow-tip-default.svg) right 3px no-repeat;
+    padding-right: 14px;
+    text-transform: capitalize;
+    font-size: inherit;
+    font-weight: 900;
+    font-family: Interstate_Bold,sans-serif,sans-serif;
+  }
+  .ventures-row { 
+    margin-bottom: 40px;
+  
+    &:last-of-type { 
+      margin-bottom: 0px;
+    }
+  
+    .spacing:last-of-type {
+      margin-right: 0;
+    }
+  
+    h4 {
+      background: linear-gradient(to left,#0556A5,#057F52);
+      background: -webkit-linear-gradient(to left,#0556A5,#057F52 40%);
+      -webkit-background-clip: text;
+      background-clip: text;
+      -webkit-text-fill-color: transparent;
+    }
+  
+    a {
+      color: #0076D1;
+      background: url(/assets/images/arrow-tip-default.svg) right 3px no-repeat;
+      padding-right: 14px;
+      text-transform: capitalize;
+      font-size: inherit;
+      font-weight: 900;
+      font-family: Interstate_Bold,sans-serif,sans-serif;
+    }
+  }
+  

--- a/src/app/ventures/ui/feature-item/feature-item.component.spec.ts
+++ b/src/app/ventures/ui/feature-item/feature-item.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { FeatureItemComponent } from './feature-item.component';
+
+describe('FeatureItemComponent', () => {
+  let component: FeatureItemComponent;
+  let fixture: ComponentFixture<FeatureItemComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ FeatureItemComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(FeatureItemComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/ventures/ui/feature-item/feature-item.component.ts
+++ b/src/app/ventures/ui/feature-item/feature-item.component.ts
@@ -1,0 +1,19 @@
+import { Component, OnInit, Input } from '@angular/core';
+import { Entry } from 'contentful';
+
+@Component({
+  selector: 'app-feature-item',
+  templateUrl: './feature-item.component.html',
+  styleUrls: ['./feature-item.component.scss']
+})
+export class FeatureItemComponent implements OnInit {
+
+  @Input() entry: Entry<any>;
+
+  constructor() { }
+
+  ngOnInit() {
+    console.log(this.entry)
+  }
+
+}

--- a/src/app/ventures/ui/feature/feature.component.html
+++ b/src/app/ventures/ui/feature/feature.component.html
@@ -10,27 +10,9 @@
     </div>
   </div>
   <div id="whatwedo-approach" class="vCarousel-container wwd">
-    <div class="row adjusted-3-col ventures-row" *ngFor="let row of entry.fields.rowData">
-      <div *ngIf="row.fields.columnType == 'Fixed'">
-        <div class="col-xs-12 col-sm-3 spacing" *ngFor="let item of row.fields.itemData">
-          <h4>{{item.fields.header}}</h4>
-          <div [innerHTML]="item.fields.description | rtToHtml"></div>
-        </div>
-      </div>
-      <div *ngIf="row.fields.columnType == 'Flex'">
-        <div [class.col-md-5]="row.fields.itemData.length == 2" 
-            [class.col-sm-5]="row.fields.itemData.length == 2"
-            [class.col-sm-3]="row.fields.itemData.length == 3" 
-            class="col-xs-12 col-sm-10 spacing"
-          *ngFor="let item of row.fields.itemData">
-          <h4>{{item.fields.header}}</h4>
-          <div [innerHTML]="item.fields.description | rtToHtml"></div>
-          <p *ngIf="item.fields.linkUrl"><a
-              href="{{item.fields.linkUrl}}"
-              class="cta chevron noGrow dark lm" target="_blank">{{item.fields.linkText}}</a></p>
-        </div>
-      </div>
-    </div>
+    <!-- start here -->
+    <app-feature-item [entry]="entry.fields.rowData"></app-feature-item>   
+    <!-- end here -->
   </div>
   <div class="row ventures-row-footer" *ngIf="entry.fields.footer">
     <div [innerHTML]="entry.fields.footer | rtToHtml"

--- a/src/app/ventures/ui/feature/feature.component.html
+++ b/src/app/ventures/ui/feature/feature.component.html
@@ -11,7 +11,7 @@
   </div>
   <div id="whatwedo-approach" class="vCarousel-container wwd">
     <!-- start here -->
-    <app-feature-item [entry]="entry.fields.rowData"></app-feature-item>   
+    <app-feature-item [entry]="entry.fields"></app-feature-item>   
     <!-- end here -->
   </div>
   <div class="row ventures-row-footer" *ngIf="entry.fields.footer">

--- a/src/app/ventures/ui/feature/feature.component.html
+++ b/src/app/ventures/ui/feature/feature.component.html
@@ -11,7 +11,119 @@
   </div>
   <div id="whatwedo-approach" class="vCarousel-container wwd">
     <!-- start here -->
-    <app-feature-item [entry]="entry.fields"></app-feature-item>   
+    <!-- <app-feature-item [entry]="entry.fields"></app-feature-item>    -->
+    <div class="row adjusted-3-col ventures-row" *ngFor="let row of entry.fields.rowData">
+      <div *ngIf="row.fields.columnType == 'Fixed'">
+        <div *ngFor="let item of row.fields.itemData">
+          <!-- TODO: Use component selectors here instead of including all the HTML for each here individually between the *ngIf contentType check -->
+          <!-- Copy Block -->
+          <div *ngIf="item.sys.contentType.sys.id === 'featureItem'">
+            <div class="col-xs-12 col-sm-3 spacing">
+              <h4>{{item.fields.header}}</h4>
+              <div [innerHTML]="item.fields.description | rtToHtml"></div>
+            </div>
+          </div>
+          <!-- Innovative -->
+          <div *ngIf="item.sys.contentType.sys.id === 'innovative'">
+            <div class="col-xs-12 col-sm-10 col-md-10 col-xs-offset-0 col-sm-offset-1">
+              <div class="success-container">
+                <div class="success-logo">
+                  <a href="{{item.fields.link}}" target="_blank"><img src="{{item.fields.logo.fields.file.url}}"
+                      alt=""></a>
+                </div>
+              </div>
+            </div>
+            <div class="col-xs-12 col-sm-5 col-md-5 col-xs-offset-0 col-sm-offset-1">
+              <div class="success-container">
+                <div class="success-quote">
+                  <div class="quote-bg">
+                    <p class="heading-3">{{item.fields.quote}}</p>
+                    <p class="author">{{item.fields.author}}</p>
+                    <p class="position">{{item.fields.position}}</p>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="col-xs-12 col-sm-5 col-md-5">
+              <p>{{item.fields.history}}</p>
+            </div>
+          </div>
+          <!-- Perspective -->
+          <div *ngIf="item.sys.contentType.sys.id === 'perspective'">
+            <div [class.col-md-10]="row.fields.itemData.length == 1" [class.col-md-5]="row.fields.itemData.length == 2"
+              class="col-sm-8 col-sm-offset-2">
+              <div [class.double]="row.fields.itemData.length == 1" [class.no-img]="!item.fields.backgroundImg"
+                class="img-gradient img-container tt-leaf">
+                <img *ngIf="!item.fields.backgroundImg" src="/assets/images/home/blank-leaf.png" class="article-bg"
+                  alt="" role="presentation">
+                <img *ngIf="item.fields.backgroundImg" src="{{item.fields.backgroundImg.fields.file.url}}"
+                  class="article-bg" alt="" role="presentation">
+                <div class="tt-content">
+                  <h5 class="eyebrow">{{item.fields.category.fields.title}}</h5>
+                  <p class="article-title">
+                    <a href="{{item.fields.link}}" target="_blank" class="">{{item.fields.title}}</a>
+                  </p>
+                  <p class="article-meta">{{item.fields.publication}}
+                    <span *ngIf="item.fields.author"> ● </span>
+                    {{item.fields.author}}
+                  </p>
+                  <p class="article-author">{{item.fields.publishDate | date:'MMMM dd, yyyy'}}</p>
+                  <p class="article-copy hidden-sm hidden-xs"
+                    *ngIf="item.fields.previewText && row.fields.itemData.length == 1">
+                    {{item.fields.previewText}}</p>
+                </div>
+              </div>
+            </div>
+          </div>
+          <!-- Circular -->
+          <div *ngIf="item.sys.contentType.sys.id === 'circular'">
+            <div [class.col-md-4]="row.fields.itemData.length == 3"
+              [class.col-sm-4]="row.fields.itemData.length == 3"
+              [class.offset-big]="row.fields.itemData.length == 3"
+              [class.col-md-5]="row.fields.itemData.length == 2"
+              [class.col-sm-5]="row.fields.itemData.length == 2" [class.inline]="row.fields.itemData.length == 2"
+              [class.col-xs-12]="row.fields.itemData.length <= 3"
+              [class.col-xs-6]="row.fields.itemData.length >= 4"
+              [class.col-md-2]="row.fields.itemData.length >= 4"
+              [class.col-sm-2]="row.fields.itemData.length >= 4"
+              [class.offset-small]="row.fields.itemData.length >= 4" class="col-center">
+              <div class="img-gradient circular img-container no-logo nolink">
+                <img src="{{item.fields.backgroundImg.fields.file.url}}" class="spotlight-bg" alt="">
+                <div class="vContent in-middle">
+                  <p *ngIf="item.fields.header" class="eyebrow asHeader lh30">{{item.fields.header}}</p>
+                  <p>{{item.fields.description}}</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div *ngIf="row.fields.columnType == 'Flex'">
+        <div *ngFor="let item of row.fields.itemData">
+          <div *ngIf="item.sys.contentType.sys.id === 'featureItem'">
+            <div [class.col-md-5]="row.fields.itemData.length == 2" [class.col-sm-5]="row.fields.itemData.length == 2"
+              [class.col-sm-3]="row.fields.itemData.length == 3" class="col-xs-12 col-sm-10 spacing">
+              <h4>{{item.fields.header}}</h4>
+              <div [innerHTML]="item.fields.description | rtToHtml"></div>
+              <p *ngIf="item.fields.linkUrl"><a href="{{item.fields.linkUrl}}" class="cta chevron noGrow dark lm"
+                  target="_blank">{{item.fields.linkText}}</a></p>
+            </div>
+          </div>
+        </div>
+
+      </div>
+
+      <div *ngFor="let item of row.fields.itemData">
+        <div *ngIf="item.sys.contentType.sys.id === 'featureItem'">
+
+        </div>
+        <div *ngIf="item.sys.contentType.sys.id === 'innovative'">
+
+        </div>
+      </div>
+    </div>
+
     <!-- end here -->
   </div>
   <div class="row ventures-row-footer" *ngIf="entry.fields.footer">

--- a/src/app/ventures/ui/feature/feature.component.html
+++ b/src/app/ventures/ui/feature/feature.component.html
@@ -1,4 +1,4 @@
-<section id="approach" class="approach container fixedSpacing ventures-feature">
+<section id="approach" class="container fixedSpacing ventures-feature">
   <div class="row">
     <div class="col-md-10 col-sm-10 col-xs-12 col-md-offset-1 col-sm-offset-1 col-xs-offset-0">
       <h2 class="vline gradient">{{entry.fields.header}}</h2>
@@ -25,7 +25,7 @@
           </div>
           <!-- Innovative -->
           <div *ngIf="item.sys.contentType.sys.id === 'innovative'">
-            <div class="col-xs-12 col-sm-10 col-md-10 col-xs-offset-0 col-sm-offset-1">
+            <div class="col-xs-12 col-sm-10 col-md-10 col-xs-offset-0">
               <div class="success-container">
                 <div class="success-logo">
                   <a href="{{item.fields.link}}" target="_blank"><img src="{{item.fields.logo.fields.file.url}}"
@@ -33,7 +33,7 @@
                 </div>
               </div>
             </div>
-            <div class="col-xs-12 col-sm-5 col-md-5 col-xs-offset-0 col-sm-offset-1">
+            <div class="col-xs-12 col-sm-5 col-md-5 col-xs-offset-0">
               <div class="success-container">
                 <div class="success-quote">
                   <div class="quote-bg">
@@ -44,14 +44,14 @@
                 </div>
               </div>
             </div>
-            <div class="col-xs-12 col-sm-5 col-md-5">
+            <div class="col-xs-12 col-sm-6 col-md-6">
               <p>{{item.fields.history}}</p>
             </div>
           </div>
           <!-- Perspective -->
           <div *ngIf="item.sys.contentType.sys.id === 'perspective'">
             <div [class.col-md-10]="row.fields.itemData.length == 1" [class.col-md-5]="row.fields.itemData.length == 2"
-              class="col-sm-8 col-sm-offset-2">
+              class="col-sm-8">
               <div [class.double]="row.fields.itemData.length == 1" [class.no-img]="!item.fields.backgroundImg"
                 class="img-gradient img-container tt-leaf">
                 <img *ngIf="!item.fields.backgroundImg" src="/assets/images/home/blank-leaf.png" class="article-bg"
@@ -76,7 +76,7 @@
             </div>
           </div>
           <!-- Circular -->
-          <div *ngIf="item.sys.contentType.sys.id === 'circular'">
+          <div class="row-center" *ngIf="item.sys.contentType.sys.id === 'circular'">
             <div [class.col-md-4]="row.fields.itemData.length == 3"
               [class.col-sm-4]="row.fields.itemData.length == 3"
               [class.offset-big]="row.fields.itemData.length == 3"

--- a/src/app/ventures/ui/feature/feature.component.scss
+++ b/src/app/ventures/ui/feature/feature.component.scss
@@ -7,15 +7,6 @@
   }
 }
 
-.ventures-feature a {
-  color: #0076D1;
-  background: url(/assets/images/arrow-tip-default.svg) right 3px no-repeat;
-  padding-right: 14px;
-  text-transform: capitalize;
-  font-size: inherit;
-  font-weight: 900;
-  font-family: Interstate_Bold,sans-serif,sans-serif;
-}
 .ventures-row { 
   margin-bottom: 40px;
 
@@ -35,13 +26,53 @@
     -webkit-text-fill-color: transparent;
   }
 
-  a {
-    color: #0076D1;
-    background: url(/assets/images/arrow-tip-default.svg) right 3px no-repeat;
-    padding-right: 14px;
-    text-transform: capitalize;
-    font-size: inherit;
-    font-weight: 900;
-    font-family: Interstate_Bold,sans-serif,sans-serif;
-  }
+  // a {
+  //   color: #0076D1;
+  //   background: url(/assets/images/arrow-tip-default.svg) right 3px no-repeat;
+  //   padding-right: 14px;
+  //   text-transform: capitalize;
+  //   font-size: inherit;
+  //   font-weight: 900;
+  //   font-family: Interstate_Bold,sans-serif,sans-serif;
+  // }
+}
+
+.perspective-container div:nth-child(1) {
+  margin-left: 8.33333333%;
+}
+.perspective-container div:nth-child(2) {
+  margin-left: 0%;
+}
+
+.row-center {
+  text-align: center;
+}
+.col-center {
+	display: inline-block;
+	vertical-align: bottom;
+}
+// .col-center.inline {
+// 	float: none;
+// }
+
+@media (min-width: 768px) {
+	// .col-center.inline:nth-of-type(3n+1) {
+	// 	margin-left: 6%;
+	// }
+	// .col-center.inline:nth-of-type(3n+0) {
+	// 	margin-right: 6%;
+	// }
+
+	// .col-center.inline:last-of-type {
+	// 	margin-right: 6%;
+	// }
+	.col-center.offset-big:nth-of-type(even) {
+		padding-top: 110px;
+	}
+	.col-center.offset-small:nth-of-type(even) {
+		padding-top: 54px;
+	}
+	.col-center.offset-small:first-of-type {
+		margin-left: 8.33333333%;
+	}
 }


### PR DESCRIPTION
This tracks issue #15, related to greater layout flexibility for the Feature component by turning it into a container for other UI components.

All UI component code in commit [7ba7070](https://github.com/kidwellington/ventures/commit/7ba70707a8940cabd87081a8ca39573ed8b6cb62) is hardcoded in `feature.component.html` for now, but should change to use the appropriate component selectors to make this cleaner. 

Because of how we're getting into two loops in 'feature.component.html` to retrieve the value of `item.sys.contentType.sys.id`, this creates some complications for how these components are rendered in the view. Ideally, i'd like to find another way of getting the `item.sys.contentType.sys.id` value to reduce this complexity in the template.